### PR TITLE
add a pymongo version check

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -6,8 +6,14 @@ from bottle import request, response, get, post
 from bottle import static_file, redirect, HTTPResponse
 from bottle import mako_view as view
 from PIL import Image
-from pymongo.objectid import ObjectId
 from models import Message
+
+from pymongo import version
+version_num = int(''.join(version.split('.')))
+if version_num > 220:
+    from bson.objectid import ObjectId
+else:
+    from pymongo.objectid import ObjectId
 
 PAGE_SIZE = 5
 


### PR DESCRIPTION
from pymongo.objectid import ObjectId

The call seems to work in versions of PyMongo < 2.2

In pymongo 2.2 or higher the call to import objectid is:

from bson.objectid import ObjectId
